### PR TITLE
Windows: cloud speech-to-text, fix key saving, fix silent dictation failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,8 +85,139 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -225,6 +356,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -477,6 +621,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -939,12 +1092,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
+ "serde",
 ]
 
 [[package]]
@@ -990,6 +1150,26 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1133,6 +1313,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1513,6 +1706,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1989,7 +2188,11 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2190,6 +2393,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2712,6 +2925,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2958,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2825,6 +3054,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +3107,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3180,6 +3434,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3410,6 +3665,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3923,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,6 +4082,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3992,6 +4304,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,6 +4417,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.3+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4484,6 +4825,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4523,6 +4875,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4887,6 +5245,7 @@ name = "whimpr-cleanup"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "hound",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4945,6 +5304,7 @@ dependencies = [
  "strsim",
  "tauri",
  "tauri-build",
+ "tauri-plugin-single-instance",
  "tracing",
  "whimpr-asr",
  "whimpr-audio",
@@ -5282,6 +5642,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5313,11 +5682,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5351,6 +5737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5361,6 +5753,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5375,10 +5773,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5393,6 +5803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5403,6 +5819,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5417,6 +5839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5427,6 +5855,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5580,6 +6014,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5678,4 +6173,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow 1.0.4",
 ]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A **local-first, cross-platform voice dictation app** — hold a key, speak, and
 | Platform | Status |
 |----------|--------|
 | **macOS 14+** | **Built and working** — developed and tested locally (Apple Silicon). |
-| **Windows 10/11** | **Built and working** — compiles and runs on real Windows 11 (MSVC). Push-to-talk (hold **Right Ctrl**), Whisper ASR, clipboard+`SendInput` paste, and cloud cleanup (OpenAI or any OpenAI-compatible API, e.g. OpenRouter) are verified end-to-end. Auto-learn dictionary capture is still macOS-only; the local (on-device) LLM cleanup worker builds but is CPU-only for now (no CUDA/Vulkan yet). |
+| **Windows 10/11** | **Built and working** — compiles and runs on real Windows 11 (MSVC), including a packaged NSIS installer (`tauri build`). Push-to-talk (hold **Right Ctrl**), Whisper ASR, clipboard+`SendInput` paste, and cloud cleanup (OpenAI or any OpenAI-compatible API, e.g. OpenRouter) are verified end-to-end. Auto-learn dictionary capture is still macOS-only; the local (on-device) LLM cleanup worker builds but is CPU-only for now (no CUDA/Vulkan yet), and only runs at all when Cleanup Engine is set to **Local** — cloud modes never load it. |
 
-Both platforms are build-from-source only for now — there's no signed installer/release pipeline yet, so `git clone` + the steps below is the way to run it on either OS.
+Both platforms build from source — there's no signed/notarized release pipeline yet (the Windows installer and macOS `.app` are unsigned), so `git clone` + the steps below is the way to run it on either OS.
 
 ---
 
@@ -64,11 +64,19 @@ Requires Rust (stable, MSVC toolchain), [CMake](https://cmake.org/download/), LL
 (for `bindgen` — set `LIBCLANG_PATH` to its `bin/` dir if it isn't auto-detected), the
 **Visual Studio Build Tools** (Desktop development with C++ workload), and Node + pnpm.
 
+> ⚠️ **Pin LLVM to the 17.x–18.x range.** `whisper-rs-sys`'s pinned `bindgen` (0.69)
+> doesn't handle the struct layout `libclang` emits on LLVM 19+ — it silently generates
+> opaque zero-field structs instead of erroring, so the build fails deep inside
+> `whisper-rs` with `no field ... on type whisper_full_params` (`available field: _address`).
+> If you hit that, uninstall LLVM and reinstall a 17.x/18.x release
+> (`winget install --id LLVM.LLVM --version 17.0.6`), then `cargo clean -p whisper-rs-sys`
+> to drop the stale bindings before rebuilding.
+
 ```powershell
 cd ui; pnpm install; cd ..
 # Dev (starts the Vite UI server + the app with hot reload):
 ui\node_modules\.bin\tauri.CMD dev
-# Or a release build:
+# Or a release build (installer lands in target\release\bundle\nsis\):
 ui\node_modules\.bin\tauri.CMD build
 ```
 

--- a/crates/whimpr-cleanup/Cargo.toml
+++ b/crates/whimpr-cleanup/Cargo.toml
@@ -12,4 +12,5 @@ whimpr-core = { path = "../whimpr-core" }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["blocking", "json", "multipart", "rustls-tls"], default-features = false }
+hound = "3"

--- a/crates/whimpr-cleanup/src/lib.rs
+++ b/crates/whimpr-cleanup/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::time::Duration;
 
+use whimpr_core::asr::{AsrEngine, AsrEngineId, Transcript};
 use whimpr_core::cleanup::{build_messages, CleanupContext, CleanupProvider, ProviderId};
 
 /// Default OpenAI Chat Completions endpoint.
@@ -167,4 +168,101 @@ impl CleanupProvider for AnthropicProvider {
         }
         Ok(text)
     }
+}
+
+/// Default OpenAI transcription endpoint.
+const OPENAI_ASR_DEFAULT_URL: &str = "https://api.openai.com/v1/audio/transcriptions";
+
+/// Speech-to-text via any OpenAI-compatible `/audio/transcriptions` API — OpenAI
+/// itself, or Groq's Whisper endpoint (`https://api.groq.com/openai/v1`), which
+/// speaks the identical multipart wire format. Same `base_url` convention as
+/// [`OpenAiProvider`], and reuses the same API key.
+pub struct CloudAsr {
+    client: reqwest::blocking::Client,
+    api_key: String,
+    model: String,
+    /// Full transcriptions URL. Defaults to OpenAI's when empty.
+    url: String,
+}
+
+impl CloudAsr {
+    /// `base_url` is the API root (e.g. `https://api.groq.com/openai/v1`), without
+    /// the `/audio/transcriptions` suffix. `None` or empty uses OpenAI directly.
+    pub fn with_base_url(
+        api_key: String,
+        model: impl Into<String>,
+        base_url: Option<String>,
+    ) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        let url = match base_url.map(|s| s.trim().trim_end_matches('/').to_string()) {
+            Some(base) if !base.is_empty() => format!("{base}/audio/transcriptions"),
+            _ => OPENAI_ASR_DEFAULT_URL.to_string(),
+        };
+        Self {
+            client,
+            api_key,
+            model: model.into(),
+            url,
+        }
+    }
+}
+
+impl AsrEngine for CloudAsr {
+    fn id(&self) -> AsrEngineId {
+        AsrEngineId::CloudWhisper
+    }
+
+    fn transcribe(&self, pcm16k: &[f32]) -> anyhow::Result<Transcript> {
+        let wav = encode_wav_16k_mono(pcm16k)?;
+        let part = reqwest::blocking::multipart::Part::bytes(wav)
+            .file_name("audio.wav")
+            .mime_str("audio/wav")?;
+        let form = reqwest::blocking::multipart::Form::new()
+            .part("file", part)
+            .text("model", self.model.clone())
+            .text("response_format", "json");
+
+        let resp = self
+            .client
+            .post(&self.url)
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let detail = resp.text().unwrap_or_default();
+            anyhow::bail!("cloud ASR HTTP {status}: {detail}");
+        }
+
+        let v: serde_json::Value = resp.json()?;
+        let text = v["text"].as_str().unwrap_or("").trim().to_string();
+        Ok(Transcript {
+            text,
+            confidence: None,
+        })
+    }
+}
+
+/// Encode 16 kHz mono f32 samples as a 16-bit PCM WAV in memory, for upload to a
+/// transcription API that expects an audio file rather than raw samples.
+fn encode_wav_16k_mono(pcm: &[f32]) -> anyhow::Result<Vec<u8>> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: 16_000,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut writer = hound::WavWriter::new(&mut buf, spec)?;
+        for &s in pcm {
+            writer.write_sample((s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)?;
+        }
+        writer.finalize()?;
+    }
+    Ok(buf.into_inner())
 }

--- a/crates/whimpr-core/src/asr/mod.rs
+++ b/crates/whimpr-core/src/asr/mod.rs
@@ -11,6 +11,9 @@ pub enum AsrEngineId {
     FluidAudioAne,
     OnnxParakeet,
     WhisperCpp,
+    /// A cloud speech-to-text API (OpenAI-compatible `/audio/transcriptions`,
+    /// e.g. OpenAI itself or Groq's Whisper endpoint).
+    CloudWhisper,
 }
 
 /// A finalized transcription result.

--- a/crates/whimpr-core/src/lib.rs
+++ b/crates/whimpr-core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod types;
 pub use asr::{AsrEngine, AsrEngineId, Transcript};
 pub use cleanup::{CleanupContext, CleanupLevel, CleanupProvider, ProviderId, VocabEntry};
 pub use dictionary::{DictSource, DictionaryEntry, DictionaryStore};
-pub use settings::{CleanupMode, Settings};
+pub use settings::{AsrMode, CleanupMode, Settings};
 pub use stats::{HistoryItem, SessionRecord, StatsStore, StatsSummary};
 pub use state::{Action, BarState, DictationState, Input, PipelineEvent, StateMachine, TriggerToken};
 pub use types::{RecordMode, SessionId};

--- a/crates/whimpr-core/src/settings.rs
+++ b/crates/whimpr-core/src/settings.rs
@@ -22,6 +22,23 @@ pub enum CleanupMode {
     Anthropic,
 }
 
+/// Which speech-to-text engine transcribes the recorded audio.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AsrMode {
+    /// Local on-device Whisper via whisper.cpp (default — works offline, no API key).
+    #[default]
+    Local,
+    /// Cloud speech-to-text via an OpenAI-compatible `/audio/transcriptions` API
+    /// (OpenAI itself, or Groq's Whisper endpoint, or any compatible host).
+    /// Reuses the same key as the "OpenAI" cleanup mode.
+    Cloud,
+}
+
+fn default_asr_model() -> String {
+    "whisper-large-v3-turbo".to_string()
+}
+
 /// Persisted user configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
@@ -34,6 +51,16 @@ pub struct Settings {
     #[serde(default)]
     pub openai_base_url: String,
     pub anthropic_model: String,
+    /// Which engine transcribes speech to text.
+    #[serde(default)]
+    pub asr_mode: AsrMode,
+    /// API root for `AsrMode::Cloud`, e.g. `https://api.groq.com/openai/v1` for
+    /// Groq's fast Whisper endpoint. Empty string means OpenAI's own endpoint.
+    /// Uses the same stored key as the "OpenAI" cleanup mode.
+    #[serde(default)]
+    pub asr_base_url: String,
+    #[serde(default = "default_asr_model")]
+    pub asr_model: String,
     /// Play the record-start ping.
     pub sound_on_start: bool,
 }
@@ -46,6 +73,9 @@ impl Default for Settings {
             openai_model: "gpt-4o-mini".to_string(),
             openai_base_url: String::new(),
             anthropic_model: "claude-haiku-4-5".to_string(),
+            asr_mode: AsrMode::default(),
+            asr_base_url: String::new(),
+            asr_model: default_asr_model(),
             sound_on_start: true,
         }
     }

--- a/docs/BUILD-STATUS.md
+++ b/docs/BUILD-STATUS.md
@@ -1,6 +1,6 @@
 # WhimprFlow — Build Status
 
-_Updated 2026-07-17. Tracks what's implemented vs. planned. Plan: `~/.claude/plans/make-a-new-project-abundant-stroustrup.md`; specs: `SPEC.md`, `ARCHITECTURE-DUAL-PLATFORM.md`._
+_Updated 2026-08-03. Tracks what's implemented vs. planned. Plan: `~/.claude/plans/make-a-new-project-abundant-stroustrup.md`; specs: `SPEC.md`, `ARCHITECTURE-DUAL-PLATFORM.md`._
 
 ## Done and verified
 
@@ -45,10 +45,13 @@ frontmost app (clipboard saved/restored). Each stage validated independently.
   push-to-talk (Right Ctrl), clipboard+`SendInput` paste, foreground-process detection, Whisper ASR
   (CPU), and the tray/overlay/Hub shell all verified running end-to-end. Also added: an
   OpenAI-compatible `base_url` on the cloud cleanup provider so Windows users without an
-  OpenAI/Anthropic key can point it at OpenRouter or similar. Remaining: GPU backend for Whisper/
-  llama.cpp (CPU-only today), UIA-based insertion beyond clipboard paste, secure-input/elevated-window
-  guards, a configurable hotkey (hardcoded to Right Ctrl), auto-learn (still macOS-only), and
-  NSIS/signing for a real installer.
+  OpenAI/Anthropic key can point it at OpenRouter or similar, and a packaged NSIS installer
+  (`tauri build` → `target\release\bundle\nsis\`). The local llama.cpp cleanup worker now only
+  spawns when Cleanup Engine is actually set to **Local** — it used to load unconditionally at
+  startup regardless of mode, which was wasted RAM/CPU on cloud-only setups. Remaining: GPU
+  backend for Whisper/llama.cpp (CPU-only today), UIA-based insertion beyond clipboard paste,
+  secure-input/elevated-window guards, a configurable hotkey (hardcoded to Right Ctrl), auto-learn
+  (still macOS-only), and signing for the installer.
 - **Dictionary auto-learn** (AX diff), history persistence + Hub history list, command mode.
 
 ## How to run what exists

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ whimpr-ipc = { path = "../crates/whimpr-ipc" }
 whimpr-audio = { path = "../crates/whimpr-audio" }
 whimpr-asr = { path = "../crates/whimpr-asr" }
 whimpr-cleanup = { path = "../crates/whimpr-cleanup" }
-keyring = "3"
+keyring = { version = "3", features = ["apple-native", "windows-native"] }
 strsim = "0.11"
 tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
 serde = { workspace = true }
@@ -38,6 +38,12 @@ windows = { version = "0.58", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_ProcessStatus",
 ] }
+
+# Only Windows/Linux need this: relaunching the exe otherwise spawns a second,
+# independent process (duplicate taskbar entry). macOS's Dock re-activates the
+# existing app instead, so the plugin isn't needed (and isn't supported) there.
+[target.'cfg(any(target_os = "windows", target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-accessibility-client = "0.0.1"

--- a/src-tauri/src/hotkey.rs
+++ b/src-tauri/src/hotkey.rs
@@ -315,6 +315,26 @@ mod imp {
                 let _ = ANTHROPIC.set(Mutex::new(anthropic));
             }
         }
+        sync_local_worker(settings.cleanup_mode);
+    }
+
+    /// Start (or stop) the local llama.cpp cleanup worker to match the current
+    /// cleanup mode — it's only worth the RAM/CPU when `Local` is actually selected.
+    fn sync_local_worker(mode: CleanupMode) {
+        let Some(slot) = LOCAL.get() else { return };
+        if matches!(mode, CleanupMode::Local) {
+            if slot.lock().unwrap().is_none() {
+                std::thread::spawn(|| {
+                    if let Some(w) = crate::local_llm::spawn_default() {
+                        if let Some(slot) = LOCAL.get() {
+                            *slot.lock().unwrap() = Some(w);
+                        }
+                    }
+                });
+            }
+        } else {
+            *slot.lock().unwrap() = None;
+        }
     }
 
     /// Clean a raw transcript per the current settings (mode + level), feeding in the
@@ -620,14 +640,8 @@ mod imp {
         let _ = SETTINGS.set(Mutex::new(settings));
         let _ = DICTIONARY.set(Mutex::new(dict));
         let _ = STATS.set(Mutex::new(whimpr_core::StatsStore::load(&stats_path())));
+        let _ = LOCAL.set(Mutex::new(None));
         rebuild_providers();
-
-        // Start the local cleanup worker in the background (model load takes a few
-        // seconds; the first local cleanup waits for it, subsequent ones are fast).
-        std::thread::spawn(|| {
-            let worker = crate::local_llm::spawn_default();
-            let _ = LOCAL.set(Mutex::new(worker));
-        });
 
         // Accessibility is the ONE permission that makes the Fn CGEventTap global AND
         // lets us post the Cmd+V paste into other apps. Without it, a keyboard tap is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,8 +3,7 @@
 //! Runs as a macOS accessory (menu-bar) app: a tray item, a transparent
 //! always-on-top Flow Bar overlay, and a hidden Hub window. This is the M0
 //! skeleton — the sidecar supervisor, real state-machine bridge, and native
-//! panel promotion arrive in later milestones. The overlay already listens for
-//! `whimpr://flowbar/state`, so the tray demo items prove the event pipeline.
+//! panel promotion arrive in later milestones.
 
 mod appctx;
 mod autolearn;
@@ -18,16 +17,11 @@ use serde::Serialize;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
-    Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
+    Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
 
 const OVERLAY_LABEL: &str = "whimpr_bar";
 const HUB_LABEL: &str = "main";
-
-#[derive(Clone, Serialize)]
-struct BarStatePayload {
-    state: &'static str,
-}
 
 /// Anchor the overlay window bottom-center of its monitor.
 fn position_overlay(w: &WebviewWindow) {
@@ -87,10 +81,6 @@ fn build_hub(app: &tauri::App) -> tauri::Result<WebviewWindow> {
         .min_inner_size(720.0, 480.0)
         .visible(true)
         .build()
-}
-
-fn emit_bar_state(app: &tauri::AppHandle, state: &'static str) {
-    let _ = app.emit_to(OVERLAY_LABEL, "whimpr://flowbar/state", BarStatePayload { state });
 }
 
 #[tauri::command]
@@ -228,8 +218,29 @@ fn set_api_key(provider: String, key: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Show and focus the Hub window, whether it's hidden (closed via the X button,
+/// which we intercept below) or just needs to come to the front.
+fn show_hub(app: &tauri::AppHandle) {
+    if let Some(w) = app.get_webview_window(HUB_LABEL) {
+        let _ = w.show();
+        let _ = w.set_focus();
+    }
+}
+
 pub fn run() {
-    tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default();
+    // Relaunching the app (double-clicking the exe/installer shortcut again) must
+    // not spawn a second process — it should just surface the running one. Without
+    // this, every relaunch left a new instance in the taskbar. macOS's Dock already
+    // re-activates the existing instance, so this is Windows/Linux-only.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            show_hub(app);
+        }));
+    }
+    builder
         .invoke_handler(tauri::generate_handler![
             get_settings,
             set_settings,
@@ -254,30 +265,34 @@ pub fn run() {
             let hub = build_hub(app)?;
             let _ = hub.show();
             let _ = hub.set_focus();
+            // Closing the Hub via the X button should hide it (dictation keeps
+            // running from the tray), not destroy the window — otherwise "Open
+            // WhimprFlow" in the tray has nothing left to show.
+            hub.on_window_event({
+                let app = app.handle().clone();
+                move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        if let Some(w) = app.get_webview_window(HUB_LABEL) {
+                            let _ = w.hide();
+                        }
+                    }
+                }
+            });
 
             // Wire the Fn key to the pill via the real state machine.
             hotkey::install(app.handle().clone());
 
             let open = MenuItem::with_id(app, "open", "Open WhimprFlow", true, None::<&str>)?;
-            let demo_rec =
-                MenuItem::with_id(app, "demo_rec", "Demo: recording", true, None::<&str>)?;
-            let demo_idle = MenuItem::with_id(app, "demo_idle", "Demo: idle", true, None::<&str>)?;
             let sep = PredefinedMenuItem::separator(app)?;
             let quit = MenuItem::with_id(app, "quit", "Quit WhimprFlow", true, None::<&str>)?;
-            let menu = Menu::with_items(app, &[&open, &demo_rec, &demo_idle, &sep, &quit])?;
+            let menu = Menu::with_items(app, &[&open, &sep, &quit])?;
 
             let mut tray = TrayIconBuilder::new()
                 .menu(&menu)
                 .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| match event.id.as_ref() {
-                    "open" => {
-                        if let Some(w) = app.get_webview_window(HUB_LABEL) {
-                            let _ = w.show();
-                            let _ = w.set_focus();
-                        }
-                    }
-                    "demo_rec" => emit_bar_state(app, "recording"),
-                    "demo_idle" => emit_bar_state(app, "idle"),
+                    "open" => show_hub(app),
                     "quit" => app.exit(0),
                     _ => {}
                 });

--- a/src-tauri/src/win.rs
+++ b/src-tauri/src/win.rs
@@ -42,7 +42,7 @@ static APP: OnceLock<AppHandle> = OnceLock::new();
 static CLOCK: OnceLock<Instant> = OnceLock::new();
 static RECORDING: AtomicBool = AtomicBool::new(false);
 static CAPTURE: OnceLock<Mutex<Option<whimpr_audio::CaptureHandle>>> = OnceLock::new();
-static ASR: OnceLock<Arc<whimpr_asr::WhisperEngine>> = OnceLock::new();
+static ASR: OnceLock<Mutex<Option<Arc<dyn AsrEngine>>>> = OnceLock::new();
 static LOCAL: OnceLock<Mutex<Option<crate::local_llm::LocalWorker>>> = OnceLock::new();
 static OPENAI: OnceLock<Mutex<Option<whimpr_cleanup::OpenAiProvider>>> = OnceLock::new();
 static SETTINGS: OnceLock<Mutex<whimpr_core::Settings>> = OnceLock::new();
@@ -92,6 +92,21 @@ fn emit_bar(state: &'static str) {
             state: &'static str,
         }
         let _ = app.emit_to(OVERLAY_LABEL, "whimpr://flowbar/state", P { state });
+    }
+}
+
+#[derive(Clone, serde::Serialize)]
+struct WavePayload {
+    bars: Vec<f32>,
+}
+
+fn emit_waveform(bars: &[f32]) {
+    if let Some(app) = APP.get() {
+        let _ = app.emit_to(
+            OVERLAY_LABEL,
+            "whimpr://audio/waveform",
+            WavePayload { bars: bars.to_vec() },
+        );
     }
 }
 
@@ -229,17 +244,32 @@ fn record_dictation(text: &str, duration_secs: f32, app: Option<String>) {
 
 // ── The push-to-talk pipeline ───────────────────────────────────────────────────
 
+/// Flash the pill to `state`, then settle back to idle after `after_ms` — the
+/// release build has no console (windows_subsystem = "windows" hides it), so this
+/// pill flash is the ONLY failure feedback the user can actually see.
+fn flash_bar(state: &'static str, after_ms: u64) {
+    emit_bar(state);
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(after_ms));
+        emit_bar("idle");
+    });
+}
+
 fn on_ptt_down() {
     if RECORDING.swap(true, Ordering::SeqCst) {
         return; // already recording
     }
     let _ = now_ms();
     emit_bar("recording");
-    std::thread::spawn(|| match whimpr_audio::start(|_: &[f32]| {}) {
+    std::thread::spawn(|| match whimpr_audio::start(emit_waveform) {
         Ok(handle) => {
             *CAPTURE.get_or_init(|| Mutex::new(None)).lock().unwrap() = Some(handle);
         }
-        Err(e) => eprintln!("[whimpr:win] mic capture failed: {e}"),
+        Err(e) => {
+            eprintln!("[whimpr:win] mic capture failed: {e}");
+            RECORDING.store(false, Ordering::SeqCst);
+            flash_bar("error", 900);
+        }
     });
 }
 
@@ -247,24 +277,45 @@ fn on_ptt_up() {
     if !RECORDING.swap(false, Ordering::SeqCst) {
         return; // wasn't recording
     }
-    emit_bar("idle");
+    emit_bar("transcribing");
     let app = foreground_app();
     let handle = CAPTURE.get().and_then(|slot| slot.lock().unwrap().take());
     std::thread::spawn(move || {
         let Some(res) = handle.and_then(|h| h.stop()) else {
+            eprintln!("[whimpr:win] no audio captured");
+            flash_bar("error", 900);
             return;
         };
-        let Some(asr) = ASR.get().cloned() else {
+        let Some(asr) = ASR.get().and_then(|m| m.lock().unwrap().clone()) else {
+            eprintln!(
+                "[whimpr:win] ASR not ready — for Local mode, is a Whisper model (e.g. \
+                 ggml-base.en.bin) present in %APPDATA%\\WhimprFlow\\models\\? For Cloud mode, \
+                 is the OpenAI-slot API key saved in Settings?"
+            );
+            flash_bar("error", 900);
             return;
         };
         let pcm = whimpr_audio::resample_to_16k(&res.samples, res.sample_rate);
-        if let Ok(t) = asr.transcribe(&pcm) {
-            let text = clean_transcript(&t.text);
-            if !text.is_empty() {
+        match asr.transcribe(&pcm) {
+            Ok(t) => {
+                eprintln!("[whimpr:win] TRANSCRIPT: \"{}\"", t.text);
+                let text = clean_transcript(&t.text);
+                if text.is_empty() {
+                    eprintln!("[whimpr:win] transcript was empty — nothing to paste");
+                    flash_bar("error", 900);
+                    return;
+                }
                 if let Err(e) = paste_text(&text) {
                     eprintln!("[whimpr:win] paste failed: {e}");
+                    flash_bar("error", 900);
+                    return;
                 }
                 record_dictation(&text, res.duration_secs(), app);
+                flash_bar("done", 500);
+            }
+            Err(e) => {
+                eprintln!("[whimpr:win] ASR error: {e}");
+                flash_bar("error", 900);
             }
         }
     });
@@ -312,16 +363,8 @@ pub fn install(app: AppHandle) {
     let _ = STATS.set(Mutex::new(whimpr_core::StatsStore::load(&stats_path())));
     let _ = OPENAI.set(Mutex::new(None));
     let _ = LOCAL.set(Mutex::new(None));
+    let _ = ASR.set(Mutex::new(None));
     rebuild_providers();
-
-    // Load Whisper.
-    std::thread::spawn(|| match whimpr_asr::WhisperEngine::load(&whisper_model_path()) {
-        Ok(engine) => {
-            let _ = ASR.set(Arc::new(engine));
-            eprintln!("[whimpr:win] ASR ready");
-        }
-        Err(e) => eprintln!("[whimpr:win] ASR load failed: {e}"),
-    });
 
     spawn_hook_thread();
     eprintln!("[whimpr:win] keyboard hook installed (push-to-talk: Right Ctrl)");
@@ -341,8 +384,8 @@ pub fn update_settings(new: whimpr_core::Settings) {
 
 pub fn rebuild_providers() {
     let settings = current_settings_inner();
-    let model = settings.openai_model;
-    let base_url = settings.openai_base_url;
+    let model = settings.openai_model.clone();
+    let base_url = settings.openai_base_url.clone();
     let key = keyring::Entry::new("com.whimpr.whimprflow", "openai_api_key")
         .ok()
         .and_then(|e| e.get_password().ok())
@@ -353,6 +396,50 @@ pub fn rebuild_providers() {
         });
     }
     sync_local_worker(settings.cleanup_mode);
+    rebuild_asr(&settings);
+}
+
+/// (Re)build the speech-to-text engine to match the current ASR mode. Cloud is
+/// built synchronously (just an HTTP client, no load time); local Whisper loads
+/// off-thread since parsing the GGUF model takes ~1s.
+fn rebuild_asr(settings: &whimpr_core::Settings) {
+    match settings.asr_mode {
+        whimpr_core::AsrMode::Cloud => {
+            let key = keyring::Entry::new("com.whimpr.whimprflow", "openai_api_key")
+                .ok()
+                .and_then(|e| e.get_password().ok())
+                .filter(|k| !k.trim().is_empty());
+            let Some(key) = key else {
+                eprintln!(
+                    "[whimpr:win] ASR: cloud mode selected but no OpenAI-slot API key is saved \
+                     (cloud ASR reuses the OpenAI API key field in Settings)"
+                );
+                return;
+            };
+            let model = settings.asr_model.clone();
+            let engine: Arc<dyn AsrEngine> = Arc::new(whimpr_cleanup::CloudAsr::with_base_url(
+                key,
+                model,
+                Some(settings.asr_base_url.clone()),
+            ));
+            if let Some(slot) = ASR.get() {
+                *slot.lock().unwrap() = Some(engine);
+            }
+            eprintln!("[whimpr:win] ASR ready (cloud)");
+        }
+        whimpr_core::AsrMode::Local => {
+            std::thread::spawn(|| match whimpr_asr::WhisperEngine::load(&whisper_model_path()) {
+                Ok(engine) => {
+                    let engine: Arc<dyn AsrEngine> = Arc::new(engine);
+                    if let Some(slot) = ASR.get() {
+                        *slot.lock().unwrap() = Some(engine);
+                    }
+                    eprintln!("[whimpr:win] ASR ready (local)");
+                }
+                Err(e) => eprintln!("[whimpr:win] ASR load failed: {e}"),
+            });
+        }
+    }
 }
 
 /// Start (or stop) the local llama.cpp cleanup worker to match the current

--- a/src-tauri/src/win.rs
+++ b/src-tauri/src/win.rs
@@ -74,6 +74,22 @@ fn whisper_model_path() -> std::path::PathBuf {
     dir.join("ggml-base.en.bin")
 }
 
+fn log_path() -> std::path::PathBuf {
+    support_dir().join("debug.log")
+}
+
+/// Release builds run detached with no console — `eprintln!` alone reaches no one.
+/// Mirror every diagnostic into `%APPDATA%\WhimprFlow\debug.log` so a user can just
+/// open a text file after reproducing a bug instead of needing a terminal.
+fn log(msg: impl std::fmt::Display) {
+    let line = format!("[{}] {msg}", unix_now());
+    eprintln!("{line}");
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(log_path()) {
+        use std::io::Write;
+        let _ = writeln!(f, "{line}");
+    }
+}
+
 fn unix_now() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -266,7 +282,7 @@ fn on_ptt_down() {
             *CAPTURE.get_or_init(|| Mutex::new(None)).lock().unwrap() = Some(handle);
         }
         Err(e) => {
-            eprintln!("[whimpr:win] mic capture failed: {e}");
+            log(format!("mic capture failed: {e}"));
             RECORDING.store(false, Ordering::SeqCst);
             flash_bar("error", 900);
         }
@@ -282,15 +298,15 @@ fn on_ptt_up() {
     let handle = CAPTURE.get().and_then(|slot| slot.lock().unwrap().take());
     std::thread::spawn(move || {
         let Some(res) = handle.and_then(|h| h.stop()) else {
-            eprintln!("[whimpr:win] no audio captured");
+            log("no audio captured");
             flash_bar("error", 900);
             return;
         };
         let Some(asr) = ASR.get().and_then(|m| m.lock().unwrap().clone()) else {
-            eprintln!(
-                "[whimpr:win] ASR not ready — for Local mode, is a Whisper model (e.g. \
-                 ggml-base.en.bin) present in %APPDATA%\\WhimprFlow\\models\\? For Cloud mode, \
-                 is the OpenAI-slot API key saved in Settings?"
+            log(
+                "ASR not ready — for Local mode, is a Whisper model (e.g. ggml-base.en.bin) \
+                 present in %APPDATA%\\WhimprFlow\\models\\? For Cloud mode, is the OpenAI-slot \
+                 API key saved in Settings?",
             );
             flash_bar("error", 900);
             return;
@@ -298,15 +314,15 @@ fn on_ptt_up() {
         let pcm = whimpr_audio::resample_to_16k(&res.samples, res.sample_rate);
         match asr.transcribe(&pcm) {
             Ok(t) => {
-                eprintln!("[whimpr:win] TRANSCRIPT: \"{}\"", t.text);
+                log(format!("TRANSCRIPT: \"{}\"", t.text));
                 let text = clean_transcript(&t.text);
                 if text.is_empty() {
-                    eprintln!("[whimpr:win] transcript was empty — nothing to paste");
+                    log("transcript was empty — nothing to paste");
                     flash_bar("error", 900);
                     return;
                 }
                 if let Err(e) = paste_text(&text) {
-                    eprintln!("[whimpr:win] paste failed: {e}");
+                    log(format!("paste failed: {e}"));
                     flash_bar("error", 900);
                     return;
                 }
@@ -314,7 +330,7 @@ fn on_ptt_up() {
                 flash_bar("done", 500);
             }
             Err(e) => {
-                eprintln!("[whimpr:win] ASR error: {e}");
+                log(format!("ASR error: {e}"));
                 flash_bar("error", 900);
             }
         }
@@ -345,7 +361,7 @@ fn spawn_hook_thread() {
         let hinst = GetModuleHandleW(None).unwrap_or_default();
         let hook = SetWindowsHookExW(WH_KEYBOARD_LL, Some(hook_proc), hinst, 0);
         if hook.is_err() {
-            eprintln!("[whimpr:win] failed to install keyboard hook");
+            log("failed to install keyboard hook");
             return;
         }
         let mut msg = MSG::default();
@@ -356,6 +372,9 @@ fn spawn_hook_thread() {
 // ── Public surface (mirrors the macOS `hotkey::` functions the commands call) ────
 
 pub fn install(app: AppHandle) {
+    // Fresh log per run — only the latest session's diagnostics matter here.
+    let _ = std::fs::create_dir_all(support_dir());
+    let _ = std::fs::write(log_path(), b"");
     let _ = APP.set(app);
     let _ = CLOCK.set(Instant::now());
     let _ = SETTINGS.set(Mutex::new(whimpr_core::Settings::load(&settings_path())));
@@ -367,7 +386,7 @@ pub fn install(app: AppHandle) {
     rebuild_providers();
 
     spawn_hook_thread();
-    eprintln!("[whimpr:win] keyboard hook installed (push-to-talk: Right Ctrl)");
+    log("keyboard hook installed (push-to-talk: Right Ctrl)");
 }
 
 pub fn current_settings() -> whimpr_core::Settings {
@@ -410,13 +429,17 @@ fn rebuild_asr(settings: &whimpr_core::Settings) {
                 .and_then(|e| e.get_password().ok())
                 .filter(|k| !k.trim().is_empty());
             let Some(key) = key else {
-                eprintln!(
-                    "[whimpr:win] ASR: cloud mode selected but no OpenAI-slot API key is saved \
-                     (cloud ASR reuses the OpenAI API key field in Settings)"
+                log(
+                    "ASR: cloud mode selected but no OpenAI-slot API key is saved (cloud ASR \
+                     reuses the OpenAI API key field in Settings)",
                 );
                 return;
             };
             let model = settings.asr_model.clone();
+            log(format!(
+                "ASR: cloud mode, model={model}, base_url={:?}",
+                settings.asr_base_url
+            ));
             let engine: Arc<dyn AsrEngine> = Arc::new(whimpr_cleanup::CloudAsr::with_base_url(
                 key,
                 model,
@@ -425,7 +448,7 @@ fn rebuild_asr(settings: &whimpr_core::Settings) {
             if let Some(slot) = ASR.get() {
                 *slot.lock().unwrap() = Some(engine);
             }
-            eprintln!("[whimpr:win] ASR ready (cloud)");
+            log("ASR ready (cloud)");
         }
         whimpr_core::AsrMode::Local => {
             std::thread::spawn(|| match whimpr_asr::WhisperEngine::load(&whisper_model_path()) {
@@ -434,9 +457,9 @@ fn rebuild_asr(settings: &whimpr_core::Settings) {
                     if let Some(slot) = ASR.get() {
                         *slot.lock().unwrap() = Some(engine);
                     }
-                    eprintln!("[whimpr:win] ASR ready (local)");
+                    log("ASR ready (local)");
                 }
-                Err(e) => eprintln!("[whimpr:win] ASR load failed: {e}"),
+                Err(e) => log(format!("ASR load failed: {e}")),
             });
         }
     }

--- a/src-tauri/src/win.rs
+++ b/src-tauri/src/win.rs
@@ -322,14 +322,6 @@ pub fn install(app: AppHandle) {
         }
         Err(e) => eprintln!("[whimpr:win] ASR load failed: {e}"),
     });
-    // Start the local cleanup worker.
-    std::thread::spawn(|| {
-        if let Some(w) = crate::local_llm::spawn_default() {
-            if let Some(slot) = LOCAL.get() {
-                *slot.lock().unwrap() = Some(w);
-            }
-        }
-    });
 
     spawn_hook_thread();
     eprintln!("[whimpr:win] keyboard hook installed (push-to-talk: Right Ctrl)");
@@ -359,6 +351,28 @@ pub fn rebuild_providers() {
         *slot.lock().unwrap() = key.map(|k| {
             whimpr_cleanup::OpenAiProvider::with_base_url(k, model, Some(base_url))
         });
+    }
+    sync_local_worker(settings.cleanup_mode);
+}
+
+/// Start (or stop) the local llama.cpp cleanup worker to match the current
+/// cleanup mode — it's only worth the RAM/CPU when `Local` is actually selected.
+/// Spawning happens off-thread since the worker process takes a few seconds to
+/// load its model; stopping just drops the child (see `LocalWorker`'s `Drop`).
+fn sync_local_worker(mode: CleanupMode) {
+    let Some(slot) = LOCAL.get() else { return };
+    if matches!(mode, CleanupMode::Local) {
+        if slot.lock().unwrap().is_none() {
+            std::thread::spawn(|| {
+                if let Some(w) = crate::local_llm::spawn_default() {
+                    if let Some(slot) = LOCAL.get() {
+                        *slot.lock().unwrap() = Some(w);
+                    }
+                }
+            });
+        }
+    } else {
+        *slot.lock().unwrap() = None;
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.1",
   "identifier": "com.whimpr.whimprflow",
   "build": {
-    "beforeDevCommand": "pnpm --dir ui dev",
+    "beforeDevCommand": "pnpm dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "pnpm --dir ui build",
+    "beforeBuildCommand": "pnpm build",
     "frontendDist": "../ui/dist"
   },
   "app": {
@@ -19,7 +19,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app", "dmg"],
+    "targets": "all",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -5,6 +5,9 @@
 packages:
   - .
 
+allowBuilds:
+  esbuild: true
+
 # esbuild ships a postinstall that fetches its platform binary; without this it
 # is skipped and vite build dies on a missing binary.
 onlyBuiltDependencies:

--- a/ui/src/hub/App.tsx
+++ b/ui/src/hub/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { font } from "../tokens/values";
 import { theme } from "./theme";
 import { Onboarding } from "./Onboarding";
@@ -62,9 +62,16 @@ export function App() {
     refresh();
   }, []);
 
+  // Each keystroke in a settings text field calls update(); saving on every one
+  // fired overlapping, unawaited Tauri calls (each doing a keyring lookup + HTTP
+  // client rebuild) with no ordering guarantee, so a fast typist could have an
+  // earlier, shorter value win the disk write over the final one. Debounce the
+  // actual save so only the settled value after typing stops gets persisted.
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const update = (s: Settings) => {
     setLocalSettings(s);
-    void setSettings(s);
+    clearTimeout(saveTimer.current);
+    saveTimer.current = setTimeout(() => void setSettings(s), 400);
   };
 
   // Gate the app behind the setup wizard until the required permissions are granted.

--- a/ui/src/hub/SettingsPane.tsx
+++ b/ui/src/hub/SettingsPane.tsx
@@ -7,11 +7,17 @@ import {
   requestInputMonitoring,
   requestMicrophone,
   setApiKey,
+  type AsrMode,
   type CleanupLevel,
   type CleanupMode,
   type Settings,
   type Status,
 } from "./api";
+
+const ASR_MODES: { value: AsrMode; label: string; hint: string }[] = [
+  { value: "local", label: "Local", hint: "On-device Whisper (offline, needs a model file in %APPDATA%\\WhimprFlow\\models\\)" },
+  { value: "cloud", label: "Cloud", hint: "Fast cloud transcription via OpenAI or an OpenAI-compatible API like Groq — reuses the OpenAI API key below." },
+];
 
 const MODES: { value: CleanupMode; label: string; hint: string }[] = [
   { value: "raw", label: "Raw", hint: "Paste exactly what you said" },
@@ -43,10 +49,10 @@ function KeyField({
 }: {
   label: string;
   configured: boolean;
-  onSave: (key: string) => void;
+  onSave: (key: string) => Promise<void>;
 }) {
   const [value, setValue] = useState("");
-  const [saved, setSaved] = useState(false);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   return (
     <div style={{ marginTop: 16 }}>
       <div style={{ fontSize: 13, marginBottom: 7, display: "flex", alignItems: "center", color: theme.textBody }}>
@@ -60,7 +66,7 @@ function KeyField({
           placeholder={configured ? "Enter a new key to replace" : "Paste your API key"}
           onChange={(e) => {
             setValue(e.target.value);
-            setSaved(false);
+            setStatus("idle");
           }}
           style={{
             flex: 1,
@@ -75,16 +81,29 @@ function KeyField({
           }}
         />
         <Button
-          onClick={() => {
-            onSave(value);
-            setValue("");
-            setSaved(true);
+          onClick={async () => {
+            setStatus("saving");
+            try {
+              await onSave(value);
+              setValue("");
+              setStatus("saved");
+            } catch (e) {
+              console.error("save key failed", e);
+              setStatus("error");
+            }
           }}
         >
           Save
         </Button>
       </div>
-      {saved && <div style={{ fontSize: 12, color: theme.accentDeep, marginTop: 6 }}>Saved to keychain ✓</div>}
+      {status === "saved" && (
+        <div style={{ fontSize: 12, color: theme.accentDeep, marginTop: 6 }}>Saved to keychain ✓</div>
+      )}
+      {status === "error" && (
+        <div style={{ fontSize: 12, color: "#e5484d", marginTop: 6 }}>
+          Couldn't save — the OS credential store may be unavailable. Check the app's console output.
+        </div>
+      )}
     </div>
   );
 }
@@ -135,6 +154,68 @@ export function SettingsPane({
       <PageTitle>Settings</PageTitle>
 
       <Card style={{ marginBottom: 16 }}>
+        <SectionTitle sub="Which engine turns your speech into text.">Speech-to-Text</SectionTitle>
+        <Segmented
+          options={ASR_MODES.map((m) => ({ value: m.value, label: m.label }))}
+          value={settings.asr_mode}
+          onChange={(v) => onChange({ ...settings, asr_mode: v })}
+        />
+        <div style={{ color: theme.textMuted, fontSize: 12.5, marginTop: 10 }}>
+          {ASR_MODES.find((m) => m.value === settings.asr_mode)?.hint}
+        </div>
+        {settings.asr_mode === "cloud" && (
+          <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 12.5, color: theme.textMuted, marginBottom: 6 }}>
+                Base URL (blank = OpenAI; e.g. https://api.groq.com/openai/v1 for Groq)
+              </div>
+              <input
+                type="text"
+                value={settings.asr_base_url}
+                placeholder="https://api.groq.com/openai/v1"
+                onChange={(e) => onChange({ ...settings, asr_base_url: e.target.value })}
+                style={{
+                  width: "100%",
+                  background: theme.cardBgSubtle,
+                  border: `1px solid ${theme.border}`,
+                  borderRadius: 10,
+                  padding: "9px 12px",
+                  color: theme.textBody,
+                  fontFamily: font.mono,
+                  fontSize: 13,
+                  outline: "none",
+                  boxSizing: "border-box",
+                }}
+              />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 12.5, color: theme.textMuted, marginBottom: 6 }}>
+                Model (e.g. whisper-large-v3-turbo for Groq, whisper-1 for OpenAI)
+              </div>
+              <input
+                type="text"
+                value={settings.asr_model}
+                placeholder="whisper-large-v3-turbo"
+                onChange={(e) => onChange({ ...settings, asr_model: e.target.value })}
+                style={{
+                  width: "100%",
+                  background: theme.cardBgSubtle,
+                  border: `1px solid ${theme.border}`,
+                  borderRadius: 10,
+                  padding: "9px 12px",
+                  color: theme.textBody,
+                  fontFamily: font.mono,
+                  fontSize: 13,
+                  outline: "none",
+                  boxSizing: "border-box",
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </Card>
+
+      <Card style={{ marginBottom: 16 }}>
         <SectionTitle sub="Where your dictation is cleaned up before it's typed.">Cleanup Engine</SectionTitle>
         <Segmented
           options={MODES.map((m) => ({ value: m.value, label: m.label }))}
@@ -148,8 +229,8 @@ export function SettingsPane({
         <KeyField
           label="OpenAI API key"
           configured={status.has_openai_key}
-          onSave={(k) => {
-            setApiKey("openai", k);
+          onSave={async (k) => {
+            await setApiKey("openai", k);
             setTimeout(refresh, 400);
           }}
         />
@@ -204,8 +285,8 @@ export function SettingsPane({
         <KeyField
           label="Anthropic API key"
           configured={status.has_anthropic_key}
-          onSave={(k) => {
-            setApiKey("anthropic", k);
+          onSave={async (k) => {
+            await setApiKey("anthropic", k);
             setTimeout(refresh, 400);
           }}
         />

--- a/ui/src/hub/api.ts
+++ b/ui/src/hub/api.ts
@@ -4,6 +4,7 @@
 
 export type CleanupMode = "raw" | "local" | "open_ai" | "anthropic";
 export type CleanupLevel = "none" | "light" | "medium" | "high";
+export type AsrMode = "local" | "cloud";
 
 export interface Settings {
   cleanup_mode: CleanupMode;
@@ -13,6 +14,13 @@ export interface Settings {
   // an OpenAI-compatible endpoint like OpenRouter (https://openrouter.ai/api/v1).
   openai_base_url: string;
   anthropic_model: string;
+  // Which engine transcribes speech to text.
+  asr_mode: AsrMode;
+  // API root for AsrMode "cloud" — leave blank for OpenAI itself, or point at
+  // Groq's Whisper endpoint (https://api.groq.com/openai/v1). Reuses the same
+  // key as the "OpenAI" cleanup mode.
+  asr_base_url: string;
+  asr_model: string;
   sound_on_start: boolean;
 }
 
@@ -56,6 +64,9 @@ export const DEFAULT_SETTINGS: Settings = {
   openai_model: "gpt-4o-mini",
   openai_base_url: "",
   anthropic_model: "claude-haiku-4-5",
+  asr_mode: "local",
+  asr_base_url: "",
+  asr_model: "whisper-large-v3-turbo",
   sound_on_start: true,
 };
 
@@ -127,12 +138,11 @@ export async function requestInputMonitoring(): Promise<void> {
   }
 }
 
+// Unlike the other wrappers, this one does NOT swallow errors — saving a key is
+// an explicit user action and a silent failure here (e.g. no OS credential store
+// available) should surface, not look like a successful save.
 export async function setApiKey(provider: "openai" | "anthropic", key: string): Promise<void> {
-  try {
-    await invoke<void>("set_api_key", { provider, key });
-  } catch {
-    /* browser preview */
-  }
+  await invoke<void>("set_api_key", { provider, key });
 }
 
 // ── History ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Windows was up and "building" per the README, but most of it was actually broken end-to-end: keys silently wouldn't save, the recording pill never animated, dictation could fail with zero feedback, and relaunching the app spawned duplicate copies. This PR fixes the root causes of all of those and adds a cloud speech-to-text path so Windows users don't need to hand-download a local Whisper model.

## What's fixed

**API keys wouldn't save (all platforms, not just Windows)**
`keyring = "3"` ships with **no storage backend compiled in by default** (v3 changed this from v2's OS-default behavior) — `Entry::set_password` was silently no-op'ing since the very first commit. Added `features = ["apple-native", "windows-native"]`. Also made the frontend surface save failures instead of always showing "Saved ✓" regardless of outcome.

**The pill never animated on Windows**
`win.rs`'s push-to-talk handler passed a no-op closure to the audio capture callback, so the `whimpr://audio/waveform` event the pill listens for was never emitted — only `hotkey.rs` (macOS) wired this up. Fixed, and while in there also wired the pill through proper `transcribing` → `done`/`error` states, which it never used on Windows.

**Dictation could fail with literally no feedback**
Release builds run with `windows_subsystem = "windows"` (no console), so every failure path's `eprintln!` was going nowhere a user could see. Now: the pill flashes an error state on any failure, and full diagnostics mirror to `%APPDATA%\WhimprFlow\debug.log`.

**Relaunching the app opened a duplicate copy**
No single-instance guard existed, so double-clicking the exe/shortcut again spawned a second independent process (duplicate taskbar entry). Added `tauri-plugin-single-instance` (Windows/Linux only — macOS's Dock already handles this). Also: closing the Hub window (X button) was destroying it, so the tray's "Open WhimprFlow" item had nothing left to show — it now hides instead. Removed the leftover "Demo: recording"/"Demo: idle" tray items.

**Settings could silently drop a field you just typed**
Every keystroke in a settings text field fired its own unawaited save-to-disk call (each doing a keyring lookup + rebuilding an HTTP client). Concurrent calls have no ordering guarantee, so a fast typist could have an earlier/emptier value win the final write — caught this live: an ASR base URL persisted as `""` even though the field showed the typed value, silently routing "Groq" requests to real OpenAI with a Groq key (401). Saves are now debounced (400ms after typing stops) instead of firing per keystroke.

**Local LLM cleanup loaded unconditionally at startup**
The llama.cpp worker was spawned regardless of Cleanup Engine mode, burning RAM/CPU even when a cloud provider was selected. Now only loads when mode is `Local`, and responds live to mode changes.

**Build/bundle config**
`beforeDevCommand`/`beforeBuildCommand` run with cwd already inside `ui/`, so `pnpm --dir ui ...` was resolving to `ui/ui` and failing on Windows. `bundle.targets` was hardcoded to macOS-only `["app","dmg"]`, silently breaking a Windows build — switched to `"all"`.

## New: Cloud speech-to-text

A new Local/Cloud toggle in Settings → Speech-to-Text. Cloud speaks the same multipart `/audio/transcriptions` wire format OpenAI and Groq share (`CloudAsr` in `whimpr-cleanup`, mirrors the existing `OpenAiProvider` base-url pattern), and reuses the OpenAI API key field rather than requiring a separate credential. This means dictation works on Windows without downloading a local Whisper model at all — point the base URL at Groq's free-tier Whisper endpoint and go.

## Testing

- `cargo test -p whimpr-core -p whimpr-ipc -p whimpr-audio` — 35 passing
- `tsc --noEmit` clean
- Verified end-to-end on Windows 11: key save/reload, push-to-talk animation, cloud ASR via Groq, tray behavior, single-instance, settings persistence across a fast-typed field
- macOS code paths (`hotkey.rs`, `paste.rs`) untouched except the local-LLM-mode gating, which is shared logic